### PR TITLE
Add code for watching additional files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "core-js": "3",
     "cross-env": "^7.0.3",
     "fs-extra": "^10.0.0",
+    "glob": "^8.0.3",
     "react-devtools": "^4.22.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.68.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,12 @@ import react from "@vitejs/plugin-react"; // BOLT-CEP_REACT-ONLY
 import vue from "@vitejs/plugin-vue"; // BOLT-CEP_VUE-ONLY
 import { svelte } from "@sveltejs/vite-plugin-svelte"; // BOLT-CEP_SVELTE-ONLY
 
+import type { Plugin } from "rollup"
+
 import { cep, runAction } from "vite-cep-plugin";
 import cepConfig from "./cep.config";
 import path from "path";
+import glob from "glob"
 import { extendscriptConfig } from "./vite.es.config";
 
 const extensions = [".js", ".ts", ".tsx"];
@@ -47,6 +50,17 @@ if (action) {
 }
 
 // https://vitejs.dev/config/
+const watcher = (globs: string[]): Plugin => ({
+  name: 'additional-file-watcher',
+  buildStart() {
+    globs.forEach((globItem) => {
+      glob.sync(path.resolve(globItem)).forEach((filename: string) => {
+        this.addWatchFile(filename)
+      })
+    })
+  },
+})
+
 export default defineConfig({
   plugins: [
     react(), // BOLT-CEP_REACT-ONLY
@@ -79,6 +93,9 @@ export default defineConfig({
         preserveModules: false,
         format: "cjs",
       },
+      plugins: [
+        watcher(["src/jsx/**"]),
+      ],
     },
     target: "chrome74",
     outDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -3038,6 +3045,17 @@ glob@^7.1.3, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-agent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-3.0.0.tgz#ae7cd31bd3583b93c5a16437a1afe27cc33a1ab6"
@@ -3540,6 +3558,13 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
Hi Team,

While running `yarn debug` changes to files in the `jsx` folder were not picked up and would not trigger a rebuild.

It looks like files aren't actually watched when included in the watch options (from what I can see in the rollup docs):

https://rollupjs.org/guide/en/#watchinclude

I've added the custom watcher plugin from https://github.com/rollup/rollup/issues/3414 which seems to fix the issue.

I wasn't sure where this needed to be added so just added to the base `vite.config.ts` file. Let me know if it needs to be added to the framework specific configs as well.

Also, what an awesome tool you have built - thank you!