### PR TITLE
remove vue dep from svelte `package.json`

### DIFF
--- a/package.svelte.json
+++ b/package.svelte.json
@@ -31,7 +31,6 @@
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^16.11.7",
     "@types/trusted-types": "^2.0.2",
-    "@vitejs/plugin-vue": "^2.3.0",
     "babel-plugin-transform-scss": "^1.1.0",
     "babel-preset-env": "^1.7.0",
     "core-js": "3",


### PR DESCRIPTION
Looks like an older `@vitejs/plugin-vue` dependency snuck into the svelte `package.json`. It throws a warning with `yarn`:
```
warning " > @vitejs/plugin-vue@2.3.4" has incorrect peer dependency "vite@^2.5.10".
warning " > @vitejs/plugin-vue@2.3.4" has unmet peer dependency "vue@^3.2.25".
```
..and an error with `npm i`:
```js
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @vitejs/plugin-vue@2.3.4
npm ERR! Found: vite@3.2.4
// ...
npm ERR! Could not resolve dependency:
npm ERR! peer vite@"^2.5.10" from @vitejs/plugin-vue@2.3.4
npm ERR! node_modules/@vitejs/plugin-vue
npm ERR!   dev @vitejs/plugin-vue@"^2.3.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: vite@2.9.15
npm ERR! node_modules/vite
npm ERR!   peer vite@"^2.5.10" from @vitejs/plugin-vue@2.3.4
// ...
```