### PR TITLE
Improve type safety

### DIFF
--- a/src/js/lib/utils.ts
+++ b/src/js/lib/utils.ts
@@ -53,7 +53,7 @@ if (namespace) {
       `try {
   ${fullString}
 } catch(e) {
-  alert("Error in function '${functionName}'\\n" + 'Call: ${functionName}(${argsString})');
+  alert("Error in function '${functionName}'\\n" + "Error message: " + e.message + "\\n" + 'Call: ${functionName}(${argsString})');
 }`,
       (res: any) => {
         resolve(res);

--- a/src/js/main/index.tsx
+++ b/src/js/main/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import "../index.scss";
 import Main from "./main";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Main />
   </React.StrictMode>

--- a/src/js/template-react/main.tsx
+++ b/src/js/template-react/main.tsx
@@ -9,14 +9,14 @@ import {
   subscribeBackgroundColor,
 } from "../lib/utils";
 
-// import reactLogo from "../assets/react.svg";
-// import viteLogo from "../assets/vite.svg";
-// import tsLogo from "../assets/typescript.svg";
-// import sassLogo from "../assets/sass.svg";
+import reactLogo from "../assets/react.svg";
+import viteLogo from "../assets/vite.svg";
+import tsLogo from "../assets/typescript.svg";
+import sassLogo from "../assets/sass.svg";
 
-// import nodeJs from "../assets/node-js.svg";
-// import adobe from "../assets/adobe.svg";
-// import bolt from "../assets/bolt-cep.svg";
+import nodeJs from "../assets/node-js.svg";
+import adobe from "../assets/adobe.svg";
+import bolt from "../assets/bolt-cep.svg";
 
 import "./main.scss";
 

--- a/src/js/template-react/main.tsx
+++ b/src/js/template-react/main.tsx
@@ -4,24 +4,27 @@ import {
   csi,
   evalES,
   evalFile,
+  evalFunction,
   openLinkInBrowser,
   subscribeBackgroundColor,
 } from "../lib/utils";
 
-import reactLogo from "../assets/react.svg";
-import viteLogo from "../assets/vite.svg";
-import tsLogo from "../assets/typescript.svg";
-import sassLogo from "../assets/sass.svg";
+// import reactLogo from "../assets/react.svg";
+// import viteLogo from "../assets/vite.svg";
+// import tsLogo from "../assets/typescript.svg";
+// import sassLogo from "../assets/sass.svg";
 
-import nodeJs from "../assets/node-js.svg";
-import adobe from "../assets/adobe.svg";
-import bolt from "../assets/bolt-cep.svg";
+// import nodeJs from "../assets/node-js.svg";
+// import adobe from "../assets/adobe.svg";
+// import bolt from "../assets/bolt-cep.svg";
 
 import "./main.scss";
 
 const Main = () => {
   const [bgColor, setBgColor] = useState("#282c34");
   const [count, setCount] = useState(0);
+
+  evalFunction("showAlert", "title", "message");
 
   const jsxTest = () => {
     console.log(evalES(`helloWorld("${csi.getApplicationID()}")`));

--- a/src/jsx/aeft/aeft.ts
+++ b/src/jsx/aeft/aeft.ts
@@ -2,3 +2,8 @@ export const helloWorld = () => {
   alert("Hello from After Effects!");
   app.project.activeItem;
 };
+
+export const showAlert = (title: string, message: string) => {
+  alert(title + "\n" + message);
+  return "Alerted";
+};

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -8,7 +8,13 @@ import * as anim from "./anim/anim";
 import * as ppro from "./ppro/ppro";
 import * as phxs from "./phxs/phxs";
 
-let main: any;
+export type Scripts = typeof aeft &
+  typeof ilst &
+  typeof anim &
+  typeof ppro &
+  typeof phxs;
+
+let main;
 
 switch (BridgeTalk.appName) {
   case "premierepro":
@@ -31,9 +37,14 @@ switch (BridgeTalk.appName) {
     //@ts-ignore
     if (app.appName === "Adobe Animate") {
       main = anim;
+    } else {
+      throw Error(
+        "Could not find scripts for app name: " + BridgeTalk.appName,
+        "src/jsx/index.ts"
+      );
     }
-    break;
 }
+
 //@ts-ignore
 const host = typeof $ !== "undefined" ? $ : window;
 host[ns] = main;

--- a/src/jsx/index.ts
+++ b/src/jsx/index.ts
@@ -46,5 +46,5 @@ switch (BridgeTalk.appName) {
 }
 
 //@ts-ignore
-const host = typeof $ !== "undefined" ? $ : window;
+const host: Record<string, any> = typeof $ !== "undefined" ? $ : window;
 host[ns] = main;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,11 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["./src"],
+  "include": [
+    "./src",
+    "./node_modules/types-for-adobe",
+    "./node_modules/types-for-adobe-extras"
+  ],
   "exclude": [
     "./src/jsx",
     "./src/js/template-*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
   "include": [
     "./src",
     "./node_modules/types-for-adobe",
-    "./node_modules/types-for-adobe-extras"
+    "./node_modules/types-for-adobe-extras",
+    "./src/jsx/global"
   ],
   "exclude": [
     "./src/jsx",

--- a/vite.config.vue.ts
+++ b/vite.config.vue.ts
@@ -21,7 +21,7 @@ const isPackage = process.env.ZXP_PACKAGE === "true";
 const isServe = process.env.SERVE_PANEL === "true";
 const action = process.env.ACTION;
 
-let input = {};
+let input: Record<string, string> = {};
 cepConfig.panels.map((panel) => {
   input[panel.name] = path.resolve(root, panel.mainPath);
 });


### PR DESCRIPTION
WIP: improving UI -> ExtendScript type safety by adding `evalFunction` as a typesafe alternative to `evalES`, that imports function types from your script files.

```js
evalFunction(functionName, ...args);
```
> **Note**
> I also experimented with adding some warnings if you accept or return non JSON primitives, which works well but might end up being confusing without custom error messaging.
>```ts
>...args: Parameters<Scripts[ScriptName]> extends JsonPrimitive[] ? Parameters<Scripts[ScriptName]> : never
>```

### Caveats

Since we're now importing types between `src/js` and `src/jsx`, type-checking with `tsc` gets a bit messed up (but things seem to work fine in VS Code).

This is mitigated by including `types-for-adobe` at the root level, but some errors persist due to conflicting `app` definitions between programs.

![image](https://user-images.githubusercontent.com/48076776/204404248-b92aa27e-5191-4da4-907c-75dd0f3c0bc8.png)

Personally I just don't type check on build, the editor warnings are enough, and the type safety benefits between UI and script functions are well worth it 😅  But will see if I can fix those remaining errors!

