### PR TITLE
Vue alias resolution for src and root directories

### DIFF
--- a/vite.config.vue.ts
+++ b/vite.config.vue.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
 import { cep, runAction } from "vite-cep-plugin";
+import { fileURLToPath, URL } from "url";
 import cepConfig from "./cep.config";
 import path from "path";
 import { extendscriptConfig } from "./vite.es.config";
@@ -50,7 +51,14 @@ if (action) {
 export default defineConfig({
   plugins: [vue(), cep(config)],
   resolve: {
-    alias: [{ find: "@esTypes", replacement: path.resolve(__dirname, "src") }],
+    alias: [
+      { find: "@esTypes", replacement: path.resolve(__dirname, "src") },
+      {
+        find: "@",
+        replacement: fileURLToPath(new URL("./src", import.meta.url)),
+      },
+      { find: "~", replacement: fileURLToPath(new URL("./", import.meta.url)) },
+    ],
   },
   root,
   clearScreen: false,


### PR DESCRIPTION
Hi Justin, I'd like Volt to be able to easily reference the already existing utilities and types contained in the Vue template by importing types from `./src/js/lib` and the like, or importing `{ fs }` from `./src/js/lib/node` for functional components like file-pickers, etc. It would be great to add this to the Vue template config not least because it also follows standard Vue practice so any one coming from Vue into Bolt would already expect to have `@` as an alias to `./src`.