### PR TITLE
making evalTS catch more kinds of ExtendScript errors

### DIFF
--- a/src/js/lib/utils/bolt.ts
+++ b/src/js/lib/utils/bolt.ts
@@ -94,8 +94,8 @@ export const evalTS = <
           //@ts-ignore
           if (res === "undefined") return resolve();
           const parsed = JSON.parse(res);
-          if (parsed.name === "ReferenceError") {
-            console.error("REFERENCE ERROR");
+          if ((typeof parsed.name === "string") && (<string>parsed.name).toLowerCase().includes("error")) {
+            console.error(parsed.message);
             reject(parsed);
           } else {
             resolve(parsed);


### PR DESCRIPTION
In some cases, `evalTS` does not properly catches ExtendScript evaluation errors, so I extended the condition of rejecting the promise that wraps the `CSInterface.evalScript` function. 