### PR TITLE
Fix returning null or undefined from ExtendScript with evalTS

### DIFF
--- a/src/js/lib/utils/bolt.ts
+++ b/src/js/lib/utils/bolt.ts
@@ -94,7 +94,7 @@ export const evalTS = <
           //@ts-ignore
           if (res === "undefined") return resolve();
           const parsed = JSON.parse(res);
-          if (parsed.name === "ReferenceError") {
+          if (parsed?.name === "ReferenceError") {
             console.error("REFERENCE ERROR");
             reject(parsed);
           } else {


### PR DESCRIPTION
Reproduction Steps:
Create an ExtendScript function which returns `null` or `undefined`, and call it using `evalTS`

Expected:
`evalTS` should resolve its promise with the value of `null` or `undefined`

Actual:
`evalTS` rejects its promise with the value of `null` or `undefined`, because the line

```
if (parsed.name === "ReferenceError") {
```

... attempts to evaluate the `.name` property or `null` or `undefined`, which raises a `TypeError`. This error is caught by the surrounding `try/catch`, which then rejects the promise with the `null` or `undefined` value.

Fix: Use safe navigation operator to access `parsed.name` so that a `TypeError` is not raised
