### PR TITLE
Fixing issue with Mac CEP not passing click events

### DIFF
--- a/src/js/main/index.html
+++ b/src/js/main/index.html
@@ -9,4 +9,5 @@
     <div id="root"></div>
     <script type="module" src="./index.tsx"></script>
   </body>
+  <script> if (window.PointerEvent) { delete window.PointerEvent; } </script>
 </html>


### PR DESCRIPTION
This is a solution to a problem where Mac CEP extensions don't get the click events because the window isn't passing them down to the app. This is reported here: https://github.com/adobe/react-spectrum/issues/854